### PR TITLE
Preserve table contents when changing editor focus

### DIFF
--- a/src/Components/TableComponent.svelte
+++ b/src/Components/TableComponent.svelte
@@ -63,11 +63,6 @@
   app.workspace.on('active-leaf-change', () => {
     if (!currSubtypeInfo?.global) {
       blockSwitch = true
-      newBatch = []
-      visibleData = []
-      promiseSortedResults = null
-      page = 0
-
       setTimeout(() => (currFile = app.workspace.getActiveFile()), 100)
     }
   })
@@ -123,6 +118,8 @@
             return filteredResults
           })
           .then((res) => {
+            page = 0
+            visibleData = []
             newBatch = res.slice(0, size)
             setTimeout(() => {
               blockSwitch = false

--- a/src/Components/UnifiedTableComponent.svelte
+++ b/src/Components/UnifiedTableComponent.svelte
@@ -66,11 +66,6 @@
   app.workspace.on('active-leaf-change', () => {
     if (!currSubtypeInfo?.global) {
       blockSwitch = true
-      newBatch = []
-      visibleData = []
-      promiseSortedResults = null
-      page = 1
-
       setTimeout(() => (currFile = app.workspace.getActiveFile()), 100)
     }
   })
@@ -120,6 +115,8 @@
             return filteredResults
           })
           .then((res) => {
+            page = 1
+            visibleData = []
             newBatch = res.slice(0, size)
             setTimeout(() => {
               blockSwitch = false


### PR DESCRIPTION
## Summary
- Keep table data visible when focus switches between editor and analysis view
- Reset pagination only after new results are ready to display

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b609bf6c608327bc5bb1bd34f71f91